### PR TITLE
describe how linux flashers need to be in the dialout group and a spelling correction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For the last few years, ham radio operators were forced to use modified hardware or external modems to play with M17 over RF.
 In mid-2024, a US-based company called Connect Systems Inc. stepped forward and released a mono-band (70cm) handheld radio - the CS7000 - with native M17 support.
-This was a huge step forward not only for the Project, but also for the whole community. No more tedious hardware modificaions necessary!
+This was a huge step forward not only for the Project, but also for the whole community. No more tedious hardware modifications necessary!
 
 CS7000 runs OpenRTX. The firmware is still being actively worked on by Silvano Seva IU2KWO.
 The current release is in the "alpha" stage, meaning that some of the functionalities might be missing.

--- a/m17/flashing_openrtx.md
+++ b/m17/flashing_openrtx.md
@@ -158,6 +158,8 @@ the OpenRTX firmware, and how to start using the M17 digital radio mode!
 
 ### Flashing from DMR to Open RTX
 
+First, make sure the user that is going to execute the flashing command is in the dialout group. Do a `getent group dialout`. If the user is not listed, do a `sudo adduser <username> dialout`, where `<username>` is the login name of the user. After this, you can verify with another `getent` command.
+
 There are are several Linux tools available for flashing the STM32 device. This section documents one command line tool, *dfu-util*, and you won't need to install any drivers. It's simple to install on Debian-based systems: `sudo apt install dfu-util`. Just like the Windows example, there are two fundamental steps to flashing your radio from the DMR firmware to the Open RTX firmware:
 
 1. Remove the read protection from the DMR firmware.


### PR DESCRIPTION
I suspect that most will already know that if you want to open a character device, you have to be in the dialout group, but it will stump a newbee.